### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ yarn add @kossnocorp/desvg
 {
   test: /\.svg$/,
   use: [
-    'desvg/react', // 👈 Add loader (use 'desvg/preact' for Preact)
-    'svg' // 👈 svg-loader must precede desvg-loader
+    'desvg-loader/react', // 👈 Add loader (use 'desvg-loader/preact' for Preact)
+    'svg-loader' // 👈 svg-loader must precede desvg-loader
   ],
 
   // or if you prefer classic:
 
-  loader: 'desvg/react!svg'
+  loader: 'desvg-loader/react!svg-loader'
 },
 // ...
 ```


### PR DESCRIPTION
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 see https://webpack.js.org/migrate/3/#automatic-loader-module-name-extension-removed